### PR TITLE
Remove monitoring of calling process

### DIFF
--- a/c_src/simdjson_nif.cpp
+++ b/c_src/simdjson_nif.cpp
@@ -223,8 +223,10 @@ static ERL_NIF_TERM parse_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[
   dom::parser parser;
   auto res  = parser.parse_into_document(*p, (const char*)bin.data, bin.size);
 
-  if (res.error()) [[unlikely]]
+  if (res.error()) [[unlikely]] {
+    enif_release_resource(p);
     return enif_make_string(env, error_message(res.error()), ERL_NIF_LATIN1);
+  }
 
   ErlNifMonitor mon;
 


### PR DESCRIPTION
The crashes I was noticing in prod seemed to be the result of at attempted double-free when removing the monitor on the simdjson 'resource' (a dom::document). I'm not exactly sure why there was a bad interaction with my geoip branch, though. Maybe it was all the extra sleeping & GC that made for the conditions of more double-free errors?

My branch appears to be happily running on prod-bidder-us-east-2. I'll keep an eye on it, but it's looking good.